### PR TITLE
Add binary file detection

### DIFF
--- a/commands/content.go
+++ b/commands/content.go
@@ -48,10 +48,17 @@ func GetContentData(rootPath string, ignorePatterns []string) ([]types.FileOutpu
 			return nil
 		}
 
+		fileType := types.NodeTypeFile
+		content := string(contentBytes)
+		if utils.IsBinary(contentBytes) {
+			fileType = types.NodeTypeBinary
+			content = ""
+		}
+
 		fileOutputs = append(fileOutputs, types.FileOutput{
 			Path:    currentPath,
-			Type:    types.NodeTypeFile,
-			Content: string(contentBytes),
+			Type:    fileType,
+			Content: content,
 		})
 		return nil
 	})

--- a/commands/tree.go
+++ b/commands/tree.go
@@ -63,7 +63,11 @@ func buildTreeNodes(currentDirectoryPath string, ignorePatterns []string, isRoot
 				node.Children = childNodes
 			}
 		} else {
-			node.Type = types.NodeTypeFile
+			if utils.IsFileBinary(childPath) {
+				node.Type = types.NodeTypeBinary
+			} else {
+				node.Type = types.NodeTypeFile
+			}
 		}
 		nodes = append(nodes, node)
 	}

--- a/main.go
+++ b/main.go
@@ -222,10 +222,14 @@ func runTreeOrContentCommand(
 			}
 		} else {
 			if command == types.CommandTree {
+				nodeType := types.NodeTypeFile
+				if utils.IsFileBinary(info.AbsolutePath) {
+					nodeType = types.NodeTypeBinary
+				}
 				collected = append(collected, &types.TreeOutputNode{
 					Path: info.AbsolutePath,
 					Name: filepath.Base(info.AbsolutePath),
-					Type: types.NodeTypeFile,
+					Type: nodeType,
 				})
 			} else {
 				data, err := os.ReadFile(info.AbsolutePath)
@@ -233,10 +237,16 @@ func runTreeOrContentCommand(
 					fmt.Fprintf(os.Stderr, "Warning: failed to read %s: %v\n", info.AbsolutePath, err)
 					continue
 				}
+				fileType := types.NodeTypeFile
+				content := string(data)
+				if utils.IsBinary(data) {
+					fileType = types.NodeTypeBinary
+					content = ""
+				}
 				collected = append(collected, &types.FileOutput{
 					Path:    info.AbsolutePath,
-					Type:    types.NodeTypeFile,
-					Content: string(data),
+					Type:    fileType,
+					Content: content,
 				})
 			}
 		}

--- a/output/output.go
+++ b/output/output.go
@@ -115,7 +115,11 @@ func RenderRaw(commandName string, documentationEntries []types.DocumentationEnt
 		case *types.FileOutput:
 			if commandName == types.CommandContent {
 				fmt.Printf("File: %s\n", v.Path)
-				fmt.Println(v.Content)
+				if v.Type == types.NodeTypeBinary {
+					fmt.Println("(binary content omitted)")
+				} else {
+					fmt.Println(v.Content)
+				}
 				fmt.Printf("End of file: %s\n", v.Path)
 				fmt.Println(separatorLine)
 			}
@@ -123,6 +127,8 @@ func RenderRaw(commandName string, documentationEntries []types.DocumentationEnt
 			if commandName == types.CommandTree {
 				if v.Type == types.NodeTypeFile {
 					fmt.Printf("[File] %s\n", v.Path)
+				} else if v.Type == types.NodeTypeBinary {
+					fmt.Printf("[Binary] %s\n", v.Path)
 				} else {
 					fmt.Printf("\n--- Directory Tree: %s ---\n", v.Path)
 					printTree(v, "")
@@ -175,8 +181,12 @@ func dedupeCollectedItems(items []interface{}) []interface{} {
 }
 
 func printTree(node *types.TreeOutputNode, prefix string) {
-	if node.Type == types.NodeTypeFile {
+	switch node.Type {
+	case types.NodeTypeFile:
 		fmt.Printf("%s[File] %s\n", prefix, node.Path)
+		return
+	case types.NodeTypeBinary:
+		fmt.Printf("%s[Binary] %s\n", prefix, node.Path)
 		return
 	}
 	fmt.Printf("%s%s\n", prefix, node.Path)

--- a/types/types.go
+++ b/types/types.go
@@ -4,6 +4,7 @@ package types
 const (
 	NodeTypeFile      = "file"
 	NodeTypeDirectory = "directory"
+	NodeTypeBinary    = "binary"
 
 	CommandTree      = "tree"
 	CommandContent   = "content"

--- a/utils/binary.go
+++ b/utils/binary.go
@@ -1,0 +1,42 @@
+package utils
+
+import (
+	"io"
+	"os"
+	"unicode/utf8"
+)
+
+const sniffLen = 8000
+
+// IsBinary reports whether the provided byte slice appears to contain binary data.
+func IsBinary(data []byte) bool {
+	if len(data) == 0 {
+		return false
+	}
+	if !utf8.Valid(data) {
+		return true
+	}
+	for _, b := range data {
+		if b == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// IsFileBinary reads up to sniffLen bytes from the file at path and determines
+// if the content appears to be binary.
+func IsFileBinary(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	buf := make([]byte, sniffLen)
+	n, err := f.Read(buf)
+	if err != nil && err != io.EOF {
+		return false
+	}
+	return IsBinary(buf[:n])
+}


### PR DESCRIPTION
## Summary
- Add new NodeTypeBinary constant and helper utilities for binary detection
- Detect and tag binary files in content and tree commands and handle them in output
- Expand tests to cover binary file handling and skip unreadable test when running as root

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68943b6fb0f48327aa36d82be0195dd1