### PR TITLE
Add nested .gitignore exclusion test and fix directory pattern matching

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -137,7 +137,7 @@ func ShouldIgnoreByPath(relativePath string, ignorePatterns []string) bool {
 			if isMatched {
 				return true
 			}
-			if isDirectoryPattern && strings.HasPrefix(normalizedPath, cleanedPattern+"/") {
+			if isDirectoryPattern && (normalizedPath == cleanedPattern || strings.HasPrefix(normalizedPath, cleanedPattern+"/")) {
 				return true
 			}
 		}


### PR DESCRIPTION
## Summary
- document TestCTX and add constants supporting new test case
- add NestedGitignoreExcluded integration test to ensure node_modules is ignored
- handle trailing-slash directory patterns in ShouldIgnoreByPath

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b9f524f31083278243c34681b37672