### PR TITLE
Remove unused xmlCallchainName constant

### DIFF
--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -23,7 +23,6 @@ const (
 	xmlHeader         = xml.Header
 	xmlRootElement    = "result"
 	xmlCallchainsName = "callchains"
-	xmlCallchainName  = "callchain"
 
 	binaryContentOmitted = "(binary content omitted)"
 	mimeTypeLabel        = "Mime Type: "


### PR DESCRIPTION
## Summary
- delete unused `xmlCallchainName` constant from output constants

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc7b4fde1c8327a42d357f79f45fb5