### PR TITLE
refactor: use shared git directory constant

### DIFF
--- a/internal/utils/buildinfo.go
+++ b/internal/utils/buildinfo.go
@@ -12,7 +12,6 @@ import (
 
 const (
 	unknownVersion = "unknown"
-	gitDirName     = ".git"
 )
 
 // GetApplicationVersion attempts to determine the application version using various methods.
@@ -56,7 +55,7 @@ func findGitDirectory(startDirectory string) (string, error) {
 
 	currentDirectory := absoluteStartDirectory
 	for {
-		gitPath := filepath.Join(currentDirectory, gitDirName)
+		gitPath := filepath.Join(currentDirectory, GitDirectoryName)
 		fileInformation, errorStat := os.Stat(gitPath)
 		if errorStat == nil && fileInformation.IsDir() {
 			return currentDirectory, nil


### PR DESCRIPTION
## Summary
- use shared constant for git directory when locating repository root

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc81156b088327b1d44b9dd4bc03e7