### PR TITLE
• Add file metadata details to context/tree outputs

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -384,18 +384,30 @@ func runTreeOrContentCommand(
 			}
 		} else {
 			if commandName == types.CommandTree {
+				fileInfo, statError := os.Stat(info.AbsolutePath)
+				if statError != nil {
+					fmt.Fprintf(os.Stderr, warningSkipPathFormat, info.AbsolutePath, statError)
+					continue
+				}
 				mimeType := utils.DetectMimeType(info.AbsolutePath)
 				nodeType := types.NodeTypeFile
 				if utils.IsFileBinary(info.AbsolutePath) {
 					nodeType = types.NodeTypeBinary
 				}
 				collected = append(collected, &types.TreeOutputNode{
-					Path:     info.AbsolutePath,
-					Name:     filepath.Base(info.AbsolutePath),
-					Type:     nodeType,
-					MimeType: mimeType,
+					Path:         info.AbsolutePath,
+					Name:         filepath.Base(info.AbsolutePath),
+					Type:         nodeType,
+					Size:         utils.FormatFileSize(fileInfo.Size()),
+					LastModified: utils.FormatTimestamp(fileInfo.ModTime()),
+					MimeType:     mimeType,
 				})
 			} else {
+				fileInfo, statError := os.Stat(info.AbsolutePath)
+				if statError != nil {
+					fmt.Fprintf(os.Stderr, warningSkipPathFormat, info.AbsolutePath, statError)
+					continue
+				}
 				fileBytes, fileReadError := os.ReadFile(info.AbsolutePath)
 				if fileReadError != nil {
 					fmt.Fprintf(os.Stderr, commands.WarningFileReadFormat, info.AbsolutePath, fileReadError)
@@ -409,10 +421,12 @@ func runTreeOrContentCommand(
 					content = ""
 				}
 				collected = append(collected, &types.FileOutput{
-					Path:     info.AbsolutePath,
-					Type:     fileType,
-					Content:  content,
-					MimeType: mimeType,
+					Path:         info.AbsolutePath,
+					Type:         fileType,
+					Content:      content,
+					Size:         utils.FormatFileSize(fileInfo.Size()),
+					LastModified: utils.FormatTimestamp(fileInfo.ModTime()),
+					MimeType:     mimeType,
 				})
 			}
 		}

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -102,6 +102,18 @@ func TestGetContentData(testingInstance *testing.T) {
 			if actual.Path != expected.Path || actual.Type != expected.Type || actual.Content != expected.Content || actual.MimeType != expected.MimeType {
 				testingInstance.Errorf("case %d (%s): mismatch at position %d", index, testCase.testName, position)
 			}
+			info, statError := os.Stat(actual.Path)
+			if statError != nil {
+				testingInstance.Fatalf("case %d (%s): stat failed for %s: %v", index, testCase.testName, actual.Path, statError)
+			}
+			expectedSize := utils.FormatFileSize(info.Size())
+			if actual.Size != expectedSize {
+				testingInstance.Errorf("case %d (%s): expected size %s for %s, got %s", index, testCase.testName, expectedSize, actual.Path, actual.Size)
+			}
+			expectedTimestamp := utils.FormatTimestamp(info.ModTime())
+			if actual.LastModified != expectedTimestamp {
+				testingInstance.Errorf("case %d (%s): expected last modified %s for %s, got %s", index, testCase.testName, expectedTimestamp, actual.Path, actual.LastModified)
+			}
 		}
 	}
 }
@@ -167,6 +179,18 @@ func TestGetTreeData(testingInstance *testing.T) {
 			expected := testCase.expectedChildren[position]
 			if actual.Path != expected.Path || actual.Type != expected.Type || actual.Name != expected.Name || actual.MimeType != expected.MimeType {
 				testingInstance.Errorf("case %d (%s): child mismatch at position %d", index, testCase.testName, position)
+			}
+			info, statError := os.Stat(actual.Path)
+			if statError != nil {
+				testingInstance.Fatalf("case %d (%s): stat failed for %s: %v", index, testCase.testName, actual.Path, statError)
+			}
+			expectedSize := utils.FormatFileSize(info.Size())
+			if actual.Size != expectedSize {
+				testingInstance.Errorf("case %d (%s): expected size %s for %s, got %s", index, testCase.testName, expectedSize, actual.Path, actual.Size)
+			}
+			expectedTimestamp := utils.FormatTimestamp(info.ModTime())
+			if actual.LastModified != expectedTimestamp {
+				testingInstance.Errorf("case %d (%s): expected last modified %s for %s, got %s", index, testCase.testName, expectedTimestamp, actual.Path, actual.LastModified)
 			}
 		}
 	}

--- a/internal/commands/content.go
+++ b/internal/commands/content.go
@@ -50,6 +50,12 @@ func GetContentData(rootPath string, ignorePatterns []string, binaryContentPatte
 			return nil
 		}
 
+		fileInfo, infoError := directoryEntry.Info()
+		if infoError != nil {
+			fmt.Fprintf(os.Stderr, WarningAccessPathFormat, walkedPath, infoError)
+			return nil
+		}
+
 		fileBytes, fileReadError := os.ReadFile(walkedPath)
 		if fileReadError != nil {
 			fmt.Fprintf(os.Stderr, WarningFileReadFormat, walkedPath, fileReadError)
@@ -69,10 +75,12 @@ func GetContentData(rootPath string, ignorePatterns []string, binaryContentPatte
 		}
 
 		fileOutputs = append(fileOutputs, types.FileOutput{
-			Path:     walkedPath,
-			Type:     fileType,
-			Content:  fileContent,
-			MimeType: mimeType,
+			Path:         walkedPath,
+			Type:         fileType,
+			Content:      fileContent,
+			Size:         utils.FormatFileSize(fileInfo.Size()),
+			LastModified: utils.FormatTimestamp(fileInfo.ModTime()),
+			MimeType:     mimeType,
 		})
 		return nil
 	})

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -4,13 +4,23 @@ import (
 	"bytes"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/temirov/ctx/internal/output"
 	"github.com/temirov/ctx/internal/types"
+	"github.com/temirov/ctx/internal/utils"
 )
 
 // textMimeTypeExpected defines the MIME type expected for text files.
 const textMimeTypeExpected = "text/plain; charset=utf-8"
+
+var sampleLastModified = time.Date(2024, time.January, 2, 3, 4, 5, 0, time.UTC)
+
+const sampleFileSize int64 = 123
+
+const sampleFileSizeHuman = "123b"
+
+var sampleLastModifiedFormatted = utils.FormatTimestamp(sampleLastModified)
 
 // callChainRawExpected defines the expected raw rendering of a call chain.
 const callChainRawExpected = "----- CALLCHAIN METADATA -----\n" +
@@ -53,7 +63,7 @@ func TestRenderCallChainRaw(testingInstance *testing.T) {
 }
 
 // jsonExpected defines the expected JSON rendering.
-const jsonExpected = "{\n" +
+var jsonExpected = "{\n" +
 	"  \"documentation\": [\n" +
 	"    {\n" +
 	"      \"type\": \"kind\",\n" +
@@ -66,6 +76,8 @@ const jsonExpected = "{\n" +
 	"      \"path\": \"file.txt\",\n" +
 	"      \"type\": \"file\",\n" +
 	"      \"content\": \"data\",\n" +
+	"      \"size\": \"" + sampleFileSizeHuman + "\",\n" +
+	"      \"lastModified\": \"" + sampleLastModifiedFormatted + "\",\n" +
 	"      \"mimeType\": \"" + textMimeTypeExpected + "\"\n" +
 	"    }\n" +
 	"  ]\n" +
@@ -77,7 +89,10 @@ const renderJSONErrorMessage = "render json error"
 // TestRenderJSON verifies RenderJSON output and deduplication.
 func TestRenderJSON(testingInstance *testing.T) {
 	docs := []types.DocumentationEntry{{Kind: "kind", Name: "name", Doc: "doc"}, {Kind: "kind", Name: "name", Doc: "doc"}}
-	items := []interface{}{&types.FileOutput{Path: "file.txt", Type: types.NodeTypeFile, Content: "data", MimeType: textMimeTypeExpected}, &types.FileOutput{Path: "file.txt", Type: types.NodeTypeFile, Content: "data", MimeType: textMimeTypeExpected}}
+	items := []interface{}{
+		&types.FileOutput{Path: "file.txt", Type: types.NodeTypeFile, Content: "data", Size: sampleFileSizeHuman, LastModified: sampleLastModifiedFormatted, MimeType: textMimeTypeExpected},
+		&types.FileOutput{Path: "file.txt", Type: types.NodeTypeFile, Content: "data", Size: sampleFileSizeHuman, LastModified: sampleLastModifiedFormatted, MimeType: textMimeTypeExpected},
+	}
 	actual, renderJSONError := output.RenderJSON(docs, items)
 	if renderJSONError != nil {
 		testingInstance.Fatalf("%s: %v", renderJSONErrorMessage, renderJSONError)
@@ -88,7 +103,7 @@ func TestRenderJSON(testingInstance *testing.T) {
 }
 
 // xmlExpected defines the expected XML rendering.
-const xmlExpected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+var xmlExpected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
 	"<result>\n" +
 	"  <documentation>\n" +
 	"    <entry>\n" +
@@ -102,6 +117,8 @@ const xmlExpected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
 	"      <path>file.txt</path>\n" +
 	"      <type>file</type>\n" +
 	"      <content>data</content>\n" +
+	"      <size>" + sampleFileSizeHuman + "</size>\n" +
+	"      <lastModified>" + sampleLastModifiedFormatted + "</lastModified>\n" +
 	"      <mimeType>" + textMimeTypeExpected + "</mimeType>\n" +
 	"      <documentation></documentation>\n" +
 	"    </item>\n" +
@@ -114,7 +131,10 @@ const renderXMLErrorMessage = "render xml error"
 // TestRenderXML verifies RenderXML output and deduplication.
 func TestRenderXML(testingInstance *testing.T) {
 	docs := []types.DocumentationEntry{{Kind: "kind", Name: "name", Doc: "doc"}, {Kind: "kind", Name: "name", Doc: "doc"}}
-	items := []interface{}{&types.FileOutput{Path: "file.txt", Type: types.NodeTypeFile, Content: "data", MimeType: textMimeTypeExpected}, &types.FileOutput{Path: "file.txt", Type: types.NodeTypeFile, Content: "data", MimeType: textMimeTypeExpected}}
+	items := []interface{}{
+		&types.FileOutput{Path: "file.txt", Type: types.NodeTypeFile, Content: "data", Size: sampleFileSizeHuman, LastModified: sampleLastModifiedFormatted, MimeType: textMimeTypeExpected},
+		&types.FileOutput{Path: "file.txt", Type: types.NodeTypeFile, Content: "data", Size: sampleFileSizeHuman, LastModified: sampleLastModifiedFormatted, MimeType: textMimeTypeExpected},
+	}
 	actual, renderXMLError := output.RenderXML(docs, items)
 	if renderXMLError != nil {
 		testingInstance.Fatalf("%s: %v", renderXMLErrorMessage, renderXMLError)
@@ -145,7 +165,9 @@ const bufferReadErrorMessage = "buffer read error"
 // TestRenderRaw verifies RenderRaw printing.
 func TestRenderRaw(testingInstance *testing.T) {
 	docs := []types.DocumentationEntry{{Kind: "kind", Name: "name", Doc: "doc"}}
-	items := []interface{}{&types.FileOutput{Path: "file.txt", Type: types.NodeTypeFile, Content: "data", MimeType: textMimeTypeExpected}}
+	items := []interface{}{
+		&types.FileOutput{Path: "file.txt", Type: types.NodeTypeFile, Content: "data", Size: sampleFileSizeHuman, LastModified: sampleLastModifiedFormatted, MimeType: textMimeTypeExpected},
+	}
 	reader, writer, pipeCreationError := os.Pipe()
 	if pipeCreationError != nil {
 		testingInstance.Fatalf("%s: %v", pipeCreationErrorMessage, pipeCreationError)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -33,17 +33,21 @@ type FileOutput struct {
 	Path          string               `json:"path" xml:"path"`
 	Type          string               `json:"type" xml:"type"`
 	Content       string               `json:"content" xml:"content"`
+	Size          string               `json:"size,omitempty" xml:"size,omitempty"`
+	LastModified  string               `json:"lastModified,omitempty" xml:"lastModified,omitempty"`
 	MimeType      string               `json:"mimeType,omitempty" xml:"mimeType,omitempty"`
 	Documentation []DocumentationEntry `json:"documentation,omitempty" xml:"documentation>entry,omitempty"`
 }
 
 // TreeOutputNode represents a node of a directory tree returned by the tree command.
 type TreeOutputNode struct {
-	Path     string            `json:"path" xml:"path"`
-	Name     string            `json:"name" xml:"name"`
-	Type     string            `json:"type" xml:"type"`
-	MimeType string            `json:"mimeType,omitempty" xml:"mimeType,omitempty"`
-	Children []*TreeOutputNode `json:"children,omitempty" xml:"children>node,omitempty"`
+	Path         string            `json:"path" xml:"path"`
+	Name         string            `json:"name" xml:"name"`
+	Type         string            `json:"type" xml:"type"`
+	Size         string            `json:"size,omitempty" xml:"size,omitempty"`
+	LastModified string            `json:"lastModified,omitempty" xml:"lastModified,omitempty"`
+	MimeType     string            `json:"mimeType,omitempty" xml:"mimeType,omitempty"`
+	Children     []*TreeOutputNode `json:"children,omitempty" xml:"children>node,omitempty"`
 }
 
 // CallChainOutput is the result of the callchain command.

--- a/internal/utils/size.go
+++ b/internal/utils/size.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+)
+
+// FormatFileSize converts a byte length into a human-readable lower-case unit string.
+func FormatFileSize(bytes int64) string {
+	if bytes < 0 {
+		return "0b"
+	}
+	units := []string{"b", "kb", "mb", "gb", "tb", "pb"}
+	value := float64(bytes)
+	unitIndex := 0
+	for value >= 1024 && unitIndex < len(units)-1 {
+		value /= 1024
+		unitIndex++
+	}
+	if unitIndex == 0 {
+		return fmt.Sprintf("%db", bytes)
+	}
+	if value < 10 {
+		formatted := fmt.Sprintf("%.1f", value)
+		formatted = strings.TrimSuffix(formatted, ".0")
+		return formatted + units[unitIndex]
+	}
+	return fmt.Sprintf("%.0f%s", value, units[unitIndex])
+}

--- a/internal/utils/timefmt.go
+++ b/internal/utils/timefmt.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"time"
+)
+
+const timestampLayout = "2006-01-02 15:04"
+
+// FormatTimestamp returns the provided time formatted using the local time zone
+// and a layout that includes date and minutes (locale-sensitive via system TZ).
+func FormatTimestamp(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.In(time.Local).Format(timestampLayout)
+}

--- a/tests/ctx_test.go
+++ b/tests/ctx_test.go
@@ -384,6 +384,18 @@ func TestCTX(testingHandle *testing.T) {
 					if files[i].MimeType != expectedTextMimeType {
 						t.Fatalf("expected MIME type %s for %s", expectedTextMimeType, files[i].Path)
 					}
+					info, err := os.Stat(files[i].Path)
+					if err != nil {
+						t.Fatalf("stat failed for %s: %v", files[i].Path, err)
+					}
+					expectedSize := utils.FormatFileSize(info.Size())
+					if files[i].Size != expectedSize {
+						t.Fatalf("expected size %s for %s, got %s", expectedSize, files[i].Path, files[i].Size)
+					}
+					expectedTimestamp := utils.FormatTimestamp(info.ModTime())
+					if files[i].LastModified != expectedTimestamp {
+						t.Fatalf("expected last modified %s for %s, got %s", expectedTimestamp, files[i].Path, files[i].LastModified)
+					}
 				}
 			},
 		},
@@ -414,6 +426,18 @@ func TestCTX(testingHandle *testing.T) {
 				if wrapper.Nodes[0].MimeType != expectedTextMimeType {
 					t.Fatalf("expected MIME type %s", expectedTextMimeType)
 				}
+				info, err := os.Stat(wrapper.Nodes[0].Path)
+				if err != nil {
+					t.Fatalf("stat failed for %s: %v", wrapper.Nodes[0].Path, err)
+				}
+				expectedSize := utils.FormatFileSize(info.Size())
+				if wrapper.Nodes[0].Size != expectedSize {
+					t.Fatalf("expected size %s, got %s", expectedSize, wrapper.Nodes[0].Size)
+				}
+				expectedTimestamp := utils.FormatTimestamp(info.ModTime())
+				if wrapper.Nodes[0].LastModified != expectedTimestamp {
+					t.Fatalf("expected last modified %s, got %s", expectedTimestamp, wrapper.Nodes[0].LastModified)
+				}
 			},
 		},
 		{
@@ -442,6 +466,18 @@ func TestCTX(testingHandle *testing.T) {
 				}
 				if wrapper.Files[0].MimeType != expectedTextMimeType {
 					t.Fatalf("expected MIME type %s", expectedTextMimeType)
+				}
+				info, err := os.Stat(wrapper.Files[0].Path)
+				if err != nil {
+					t.Fatalf("stat failed for %s: %v", wrapper.Files[0].Path, err)
+				}
+				expectedSize := utils.FormatFileSize(info.Size())
+				if wrapper.Files[0].Size != expectedSize {
+					t.Fatalf("expected size %s, got %s", expectedSize, wrapper.Files[0].Size)
+				}
+				expectedTimestamp := utils.FormatTimestamp(info.ModTime())
+				if wrapper.Files[0].LastModified != expectedTimestamp {
+					t.Fatalf("expected last modified %s, got %s", expectedTimestamp, wrapper.Files[0].LastModified)
 				}
 			},
 		},
@@ -671,6 +707,18 @@ func TestCTX(testingHandle *testing.T) {
 				if files[0].MimeType != expectedTextMimeType {
 					t.Fatalf("expected MIME type %s", expectedTextMimeType)
 				}
+				expectedSize := utils.FormatFileSize(int64(len("OK")))
+				if files[0].Size != expectedSize {
+					t.Fatalf("expected size %s, got %s", expectedSize, files[0].Size)
+				}
+				info, err := os.Stat(files[0].Path)
+				if err != nil {
+					t.Fatalf("stat failed for %s: %v", files[0].Path, err)
+				}
+				expectedTimestamp := utils.FormatTimestamp(info.ModTime())
+				if files[0].LastModified != expectedTimestamp {
+					t.Fatalf("expected last modified %s, got %s", expectedTimestamp, files[0].LastModified)
+				}
 			},
 		},
 		{
@@ -706,6 +754,22 @@ func TestCTX(testingHandle *testing.T) {
 				if fileOutput.MimeType != expectedBinaryMimeType {
 					t.Fatalf("expected MIME type %q, got %q", expectedBinaryMimeType, fileOutput.MimeType)
 				}
+				binaryBytes, decodeError := base64.StdEncoding.DecodeString(onePixelPNGBase64Content)
+				if decodeError != nil {
+					t.Fatalf("failed to decode binary fixture during validation: %v", decodeError)
+				}
+				expectedSize := utils.FormatFileSize(int64(len(binaryBytes)))
+				if fileOutput.Size != expectedSize {
+					t.Fatalf("expected size %s, got %s", expectedSize, fileOutput.Size)
+				}
+				info, err := os.Stat(fileOutput.Path)
+				if err != nil {
+					t.Fatalf("stat failed for %s: %v", fileOutput.Path, err)
+				}
+				expectedTimestamp := utils.FormatTimestamp(info.ModTime())
+				if fileOutput.LastModified != expectedTimestamp {
+					t.Fatalf("expected last modified %s, got %s", expectedTimestamp, fileOutput.LastModified)
+				}
 			},
 		},
 		{
@@ -740,6 +804,22 @@ func TestCTX(testingHandle *testing.T) {
 				}
 				if child.MimeType != expectedBinaryMimeType {
 					t.Fatalf("expected MIME type %q, got %q", expectedBinaryMimeType, child.MimeType)
+				}
+				binaryBytes, decodeError := base64.StdEncoding.DecodeString(onePixelPNGBase64Content)
+				if decodeError != nil {
+					t.Fatalf("failed to decode binary fixture during validation: %v", decodeError)
+				}
+				expectedSize := utils.FormatFileSize(int64(len(binaryBytes)))
+				if child.Size != expectedSize {
+					t.Fatalf("expected size %s, got %s", expectedSize, child.Size)
+				}
+				info, err := os.Stat(child.Path)
+				if err != nil {
+					t.Fatalf("stat failed for %s: %v", child.Path, err)
+				}
+				expectedTimestamp := utils.FormatTimestamp(info.ModTime())
+				if child.LastModified != expectedTimestamp {
+					t.Fatalf("expected last modified %s, got %s", expectedTimestamp, child.LastModified)
 				}
 			},
 		},
@@ -876,6 +956,18 @@ func TestCTX(testingHandle *testing.T) {
 				if children[0].MimeType != expectedTextMimeType {
 					t.Fatalf("expected MIME type %s", expectedTextMimeType)
 				}
+				expectedSize := utils.FormatFileSize(int64(len(visibleFileContent)))
+				if children[0].Size != expectedSize {
+					t.Fatalf("expected size %s, got %s", expectedSize, children[0].Size)
+				}
+				info, err := os.Stat(children[0].Path)
+				if err != nil {
+					t.Fatalf("stat failed for %s: %v", children[0].Path, err)
+				}
+				expectedTimestamp := utils.FormatTimestamp(info.ModTime())
+				if children[0].LastModified != expectedTimestamp {
+					t.Fatalf("expected last modified %s, got %s", expectedTimestamp, children[0].LastModified)
+				}
 			},
 		},
 		{
@@ -912,6 +1004,18 @@ func TestCTX(testingHandle *testing.T) {
 				}
 				if visibleNode.MimeType != expectedTextMimeType {
 					t.Fatalf("expected MIME type %s", expectedTextMimeType)
+				}
+				expectedSize := utils.FormatFileSize(int64(len(visibleFileContent)))
+				if visibleNode.Size != expectedSize {
+					t.Fatalf("expected size %s, got %s", expectedSize, visibleNode.Size)
+				}
+				info, err := os.Stat(visibleNode.Path)
+				if err != nil {
+					t.Fatalf("stat failed for %s: %v", visibleNode.Path, err)
+				}
+				expectedTimestamp := utils.FormatTimestamp(info.ModTime())
+				if visibleNode.LastModified != expectedTimestamp {
+					t.Fatalf("expected last modified %s, got %s", expectedTimestamp, visibleNode.LastModified)
 				}
 			},
 		},
@@ -977,11 +1081,26 @@ func TestCTX(testingHandle *testing.T) {
 					t.Fatalf("expected root child %s, got %#v", subDirectoryName, rootChildren)
 				}
 				subNode := rootChildren[0]
+				if subNode.Size != "" {
+					t.Fatalf("expected directory %s to omit size, got %q", subDirectoryName, subNode.Size)
+				}
 				if len(subNode.Children) != 1 || subNode.Children[0].Name != visibleFileName {
 					t.Fatalf("expected only %s in %s, got %#v", visibleFileName, subDirectoryName, subNode.Children)
 				}
 				if subNode.Children[0].MimeType != expectedTextMimeType {
 					t.Fatalf("expected MIME type %s", expectedTextMimeType)
+				}
+				expectedSize := utils.FormatFileSize(int64(len(visibleFileContent)))
+				if subNode.Children[0].Size != expectedSize {
+					t.Fatalf("expected size %s, got %s", expectedSize, subNode.Children[0].Size)
+				}
+				info, err := os.Stat(subNode.Children[0].Path)
+				if err != nil {
+					t.Fatalf("stat failed for %s: %v", subNode.Children[0].Path, err)
+				}
+				expectedTimestamp := utils.FormatTimestamp(info.ModTime())
+				if subNode.Children[0].LastModified != expectedTimestamp {
+					t.Fatalf("expected last modified %s, got %s", expectedTimestamp, subNode.Children[0].LastModified)
 				}
 			},
 		},
@@ -1021,6 +1140,18 @@ func TestCTX(testingHandle *testing.T) {
 				}
 				if fileOutput.MimeType != expectedTextMimeType {
 					testingHandle.Fatalf("expected MIME type %s", expectedTextMimeType)
+				}
+				expectedSize := utils.FormatFileSize(int64(len(visibleFileContent)))
+				if fileOutput.Size != expectedSize {
+					testingHandle.Fatalf("expected size %s, got %s", expectedSize, fileOutput.Size)
+				}
+				info, err := os.Stat(fileOutput.Path)
+				if err != nil {
+					testingHandle.Fatalf("stat failed for %s: %v", fileOutput.Path, err)
+				}
+				expectedTimestamp := utils.FormatTimestamp(info.ModTime())
+				if fileOutput.LastModified != expectedTimestamp {
+					testingHandle.Fatalf("expected last modified %s, got %s", expectedTimestamp, fileOutput.LastModified)
 				}
 			},
 		},


### PR DESCRIPTION
  - track file sizes as human-readable strings and omit directory sizes
  - format last-modified timestamps as local date/time up to minutes
  - extend tree/content collectors and CLI direct-path handling with new formatting helpers
  - add utils.FormatFileSize and utils.FormatTimestamp utilities
  - update JSON/XML/raw render tests plus unit/integration suites to assert the new size and timestamp formats