### PR TITLE
gix/add-bundle-command-to-build-goal-oriented-context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,13 @@
 # AGENTS.md
 
+## Forward-Only Contract Discipline
+
+This repository follows a forward-only, confident programming paradigm. This is a binding agent contract: no fallbacks, no backward compatibility, no legacy support, and no compatibility shims. Do not spend design or implementation effort on backward compatibility considerations except for explicit one-off data migrations into the current canonical contract.
+
+Repeat for emphasis because this rule is binding: no fallbacks, no backward compatibility, no legacy compatibility. Delete or reject obsolete code paths, stale schemas, deprecated config, and old persisted shapes instead of preserving them through compatibility layers, dual reads/writes, aliases, or best-effort recovery.
+
+One-off data migrations are allowed only when they move existing persisted data into the current schema in a bounded operation. After migration, remove the bridge and keep only the current contract.
+
 ## CTX
 
 `ctx` is a command-line tool written in Go that displays a directory tree view, outputs file contents for specified

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -74,12 +74,14 @@ Use --format to select toon, raw, json, or xml output. Use --doc to include docu
 	treeUse                   = "tree [paths...]"
 	contentUse                = "content [paths...]"
 	callchainUse              = "callchain <function>"
+	bundleUse                 = "bundle"
 	treeAlias                 = "t"
 	contentAlias              = "c"
 	callchainAlias            = "cc"
 	treeShortDescription      = "display directory tree (" + treeAlias + ")"
 	contentShortDescription   = "show file contents (" + contentAlias + ")"
 	callchainShortDescription = "analyze call chains (" + callchainAlias + ")"
+	bundleShortDescription    = "build goal-oriented execution context"
 
 	// treeLongDescription provides detailed help for the tree command.
 	treeLongDescription = `List directories and files for one or more paths.
@@ -110,6 +112,11 @@ Use --depth to control traversal depth, --format for output selection, and --doc
 
   # Produce XML output including documentation
   ctx callchain mypkg.MyFunc --format xml --doc`
+
+	bundleLongDescription = `Build a goal-oriented repository context bundle from a JSON request.
+The bundle command emits the canonical context contract used by agentic execution. It supports json and toon output.`
+	bundleUsageExample = `  # Render an execution context bundle in TOON
+  ctx bundle --request /tmp/context-request.json --format toon`
 
 	docUse              = "doc"
 	docAlias            = "d"
@@ -158,6 +165,8 @@ Provide an optional path argument or --root to set the project directory. Use --
 	docDiscoverPyPIBaseFlagName        = "pypi-registry-base"
 	docDiscoverFormatDescription       = "output format (text|json)"
 	docDiscoverSummaryTemplate         = "Dependencies processed: %d (written: %d, skipped: %d, failed: %d)\n"
+	bundleRequestFlagName              = "request"
+	bundleRequestFlagDescription       = "path to the context bundle request JSON"
 
 	docWebDepthFlagName    = "web-depth"
 	docWebDepthDescription = "maximum link depth for external pages (0-3); 0 fetches only the provided page"
@@ -207,6 +216,7 @@ Provide an optional path argument or --root to set the project directory. Use --
 	documentationFlagDescription    = "documentation mode (disabled|relevant|full)"
 	contentFlagDescription          = "include file content in output"
 	invalidFormatMessage            = "Invalid format value '%s'"
+	invalidBundleFormatMessage      = "bundle supports toon or json output"
 	invalidDocumentationModeMessage = "invalid documentation mode '%s'"
 	warningSkipPathFormat           = "Warning: skipping %s: %v\n"
 	warningTokenCountFormat         = "Warning: failed to count tokens for %s: %v\n"
@@ -336,6 +346,7 @@ func createRootCommand(clipboardProvider clipboard.Copier) *cobra.Command {
 		createTreeCommand(clipboardProvider, &copyFlagValue, &copyOnlyFlagValue, &applicationConfig),
 		createContentCommand(clipboardProvider, &copyFlagValue, &copyOnlyFlagValue, &applicationConfig),
 		createCallChainCommand(clipboardProvider, &copyFlagValue, &copyOnlyFlagValue, &applicationConfig, callChainService),
+		createBundleCommand(clipboardProvider, &copyFlagValue, &copyOnlyFlagValue),
 		createDocCommand(clipboardProvider, &copyFlagValue, &copyOnlyFlagValue, &applicationConfig),
 	)
 	rootCommand.InitDefaultHelpCmd()
@@ -641,6 +652,95 @@ func createCallChainCommand(clipboardProvider clipboard.Copier, copyFlag *bool, 
 		docsAPIFlag.Hidden = true
 	}
 	return callChainCommand
+}
+
+func createBundleCommand(clipboardProvider clipboard.Copier, copyFlag *bool, copyOnlyFlag *bool) *cobra.Command {
+	var outputFormat string = types.FormatToon
+	var requestPath string
+
+	bundleCommand := &cobra.Command{
+		Use:     bundleUse,
+		Short:   bundleShortDescription,
+		Long:    bundleLongDescription,
+		Example: bundleUsageExample,
+		Args:    cobra.NoArgs,
+		RunE: func(command *cobra.Command, arguments []string) error {
+			outputFormatLower := strings.ToLower(outputFormat)
+			if outputFormatLower != types.FormatToon && outputFormatLower != types.FormatJSON {
+				return fmt.Errorf(invalidBundleFormatMessage)
+			}
+			if strings.TrimSpace(requestPath) == "" {
+				return fmt.Errorf("%s is required", bundleRequestFlagName)
+			}
+			requestBytes, readErr := os.ReadFile(requestPath)
+			if readErr != nil {
+				return fmt.Errorf("read bundle request: %w", readErr)
+			}
+			var request types.ContextBundleRequest
+			if decodeErr := json.Unmarshal(requestBytes, &request); decodeErr != nil {
+				return fmt.Errorf("decode bundle request: %w", decodeErr)
+			}
+			if strings.TrimSpace(request.Model) == "" {
+				request.Model = defaultTokenizerModelName
+			}
+			counter, resolvedModel, counterErr := tokenizer.NewCounter(tokenizer.Config{
+				Model:            request.Model,
+				WorkingDirectory: request.RepositoryRoot,
+			})
+			if counterErr != nil {
+				if errors.Is(counterErr, tokenizer.ErrHelperUnavailable) {
+					return fmt.Errorf("token helper unavailable: %w", counterErr)
+				}
+				return counterErr
+			}
+			bundle, bundleErr := commands.BuildContextBundle(command.Context(), commands.ContextBundleOptions{
+				Request:      request,
+				TokenCounter: counter,
+				TokenModel:   resolvedModel,
+			})
+			if bundleErr != nil {
+				return bundleErr
+			}
+			renderedOutput := output.RenderContextBundleToon(bundle)
+			if outputFormatLower == types.FormatJSON {
+				renderedJSON, renderErr := output.RenderContextBundleJSON(bundle)
+				if renderErr != nil {
+					return renderErr
+				}
+				renderedOutput = renderedJSON
+			}
+			writer := command.OutOrStdout()
+			copyEnabled := copyFlag != nil && *copyFlag
+			copyOnlyEnabled := copyOnlyFlag != nil && *copyOnlyFlag
+			if copyOnlyEnabled {
+				copyEnabled = true
+			}
+			var clipboardBuffer *bytes.Buffer
+			if copyEnabled {
+				if clipboardProvider == nil {
+					return errors.New(clipboardServiceMissingMessage)
+				}
+				clipboardBuffer = &bytes.Buffer{}
+				if copyOnlyEnabled {
+					writer = clipboardBuffer
+				} else {
+					writer = io.MultiWriter(writer, clipboardBuffer)
+				}
+			}
+			if _, writeErr := fmt.Fprintln(writer, renderedOutput); writeErr != nil {
+				return writeErr
+			}
+			if clipboardBuffer != nil {
+				if copyErr := clipboardProvider.Copy(clipboardBuffer.String()); copyErr != nil {
+					return fmt.Errorf(clipboardCopyErrorFormat, copyErr)
+				}
+			}
+			return nil
+		},
+	}
+	bundleCommand.Flags().StringVar(&requestPath, bundleRequestFlagName, "", bundleRequestFlagDescription)
+	bundleCommand.Flags().StringVar(&outputFormat, formatFlagName, types.FormatToon, formatFlagDescription)
+	return bundleCommand
 }
 
 func createDocCommand(clipboardProvider clipboard.Copier, copyFlag *bool, copyOnlyFlag *bool, applicationConfig *config.ApplicationConfiguration) *cobra.Command {

--- a/internal/commands/context_bundle.go
+++ b/internal/commands/context_bundle.go
@@ -1,0 +1,597 @@
+package commands
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/tyemirov/ctx/internal/config"
+	"github.com/tyemirov/ctx/internal/tokenizer"
+	"github.com/tyemirov/ctx/internal/types"
+	"github.com/tyemirov/ctx/internal/utils"
+)
+
+const (
+	contextBundleVersion        = 1
+	defaultContextBundleTokens  = 24000
+	contextBundleContractRunes  = 12000
+	contextBundleFileRunes      = 16000
+	contextBundleMaxFileBytes   = 512 * 1024
+	contextBundleGeneratedBy    = "ctx bundle"
+	contextBundleRoleContract   = "contract"
+	contextBundleRoleIssueDoc   = "issue-document"
+	contextBundleRolePlan       = "plan"
+	contextBundleRoleImpl       = "implementation"
+	contextBundleRoleTest       = "test"
+	contextBundleRoleDocs       = "docs"
+	contextBundleRoleRuntime    = "runtime"
+	contextBundleRoleConfig     = "config"
+	contextBundleRoleAsset      = "asset"
+	contextBundleReasonContract = "binding repository contract"
+)
+
+var contextBundleWordPattern = regexp.MustCompile(`[A-Za-z0-9_]+`)
+
+var contextBundleStopWords = map[string]struct{}{
+	"about": {}, "after": {}, "agent": {}, "agents": {}, "also": {}, "and": {}, "any": {}, "are": {},
+	"can": {}, "could": {}, "for": {}, "from": {}, "goal": {}, "have": {}, "how": {}, "into": {},
+	"its": {}, "new": {}, "not": {}, "now": {}, "our": {}, "out": {}, "put": {}, "properly": {},
+	"should": {}, "stage": {}, "that": {}, "the": {}, "then": {}, "there": {}, "this": {}, "tool": {},
+	"use": {}, "want": {}, "when": {}, "with": {}, "work": {}, "would": {},
+}
+
+var contextBundleDefaultExclusions = []string{
+	".git/",
+	".cache/",
+	"node_modules/",
+	"vendor/",
+	"dist/",
+	"build/",
+	"coverage/",
+	"tmp/",
+	"*.png",
+	"*.jpg",
+	"*.jpeg",
+	"*.gif",
+	"*.webp",
+	"*.pdf",
+	"*.zip",
+	"*.tar",
+	"*.gz",
+}
+
+// ContextBundleOptions configures goal-oriented bundle extraction.
+type ContextBundleOptions struct {
+	Request      types.ContextBundleRequest
+	TokenCounter tokenizer.Counter
+	TokenModel   string
+}
+
+type contextBundleCandidate struct {
+	path      string
+	role      string
+	reason    string
+	score     int
+	content   string
+	lineStart int
+	lineEnd   int
+	tokens    int
+	hash      string
+}
+
+// BuildContextBundle assembles deterministic repository context for a concrete execution goal.
+func BuildContextBundle(ctx context.Context, options ContextBundleOptions) (*types.ContextBundleOutput, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	request := normalizeContextBundleRequest(options.Request)
+	if strings.TrimSpace(request.RepositoryRoot) == "" {
+		return nil, fmt.Errorf("repositoryRoot is required")
+	}
+	if strings.TrimSpace(request.Goal.Title) == "" && strings.TrimSpace(request.Goal.ID) == "" {
+		return nil, fmt.Errorf("goal.title or goal.id is required")
+	}
+	if options.TokenCounter == nil {
+		return nil, fmt.Errorf("token counter is required")
+	}
+	repositoryRoot, rootErr := filepath.Abs(request.RepositoryRoot)
+	if rootErr != nil {
+		return nil, fmt.Errorf("resolve repository root: %w", rootErr)
+	}
+	rootInfo, statErr := os.Stat(repositoryRoot)
+	if statErr != nil {
+		return nil, fmt.Errorf("stat repository root: %w", statErr)
+	}
+	if !rootInfo.IsDir() {
+		return nil, fmt.Errorf("repositoryRoot must be a directory")
+	}
+
+	maxTokens := request.MaxTokens
+	if maxTokens <= 0 {
+		maxTokens = defaultContextBundleTokens
+	}
+	tokenModel := strings.TrimSpace(options.TokenModel)
+	if tokenModel == "" {
+		tokenModel = strings.TrimSpace(request.Model)
+	}
+	terms := deriveContextBundleTerms(request)
+	ignorePatterns, _, ignoreErr := config.LoadRecursiveIgnorePatterns(
+		repositoryRoot,
+		append(append([]string{}, contextBundleDefaultExclusions...), request.ExcludePaths...),
+		true,
+		true,
+		false,
+	)
+	if ignoreErr != nil {
+		return nil, fmt.Errorf("load ignore patterns: %w", ignoreErr)
+	}
+
+	var contracts []contextBundleCandidate
+	var files []contextBundleCandidate
+	var exclusions []types.ContextBundleExclusion
+	walkErr := filepath.WalkDir(repositoryRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		relativePath := utils.RelativePathOrSelf(path, repositoryRoot)
+		if relativePath == "." {
+			return nil
+		}
+		relativePath = filepath.ToSlash(relativePath)
+		if utils.ShouldIgnoreByPath(relativePath, ignorePatterns) {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			return infoErr
+		}
+		if info.Size() > contextBundleMaxFileBytes {
+			exclusions = appendContextBundleExclusion(exclusions, types.ContextBundleExclusion{
+				Path:   relativePath,
+				Role:   classifyContextBundleRole(relativePath, request),
+				Reason: "file exceeds context bundle size limit",
+			})
+			return nil
+		}
+		contentBytes, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		if utils.IsBinary(contentBytes) || !utf8.Valid(contentBytes) {
+			exclusions = appendContextBundleExclusion(exclusions, types.ContextBundleExclusion{
+				Path:   relativePath,
+				Role:   classifyContextBundleRole(relativePath, request),
+				Reason: "binary file omitted",
+			})
+			return nil
+		}
+		role := classifyContextBundleRole(relativePath, request)
+		content := string(contentBytes)
+		score, reason := scoreContextBundleFile(relativePath, content, role, terms, request.IncludePaths)
+		if role == contextBundleRoleContract || role == contextBundleRoleIssueDoc || role == contextBundleRolePlan {
+			item, itemErr := buildContextBundleCandidate(relativePath, role, contextBundleReason(relativePath, role, reason), 1000+score, content, contextBundleContractRunes, options.TokenCounter)
+			if itemErr != nil {
+				return itemErr
+			}
+			contracts = append(contracts, item)
+			return nil
+		}
+		if score <= 0 {
+			exclusions = appendContextBundleExclusion(exclusions, types.ContextBundleExclusion{
+				Path:   relativePath,
+				Role:   role,
+				Reason: "no goal term match",
+				Score:  score,
+			})
+			return nil
+		}
+		item, itemErr := buildContextBundleCandidate(relativePath, role, reason, score, content, contextBundleFileRunes, options.TokenCounter)
+		if itemErr != nil {
+			return itemErr
+		}
+		files = append(files, item)
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+
+	sortContextBundleCandidates(contracts)
+	sortContextBundleCandidates(files)
+
+	var usedTokens int
+	selectedContracts := make([]types.ContextBundleItem, 0, len(contracts))
+	for _, candidate := range contracts {
+		if candidate.tokens > maxTokens && len(selectedContracts) > 0 {
+			exclusions = appendContextBundleExclusion(exclusions, contextBundleBudgetExclusion(candidate))
+			continue
+		}
+		selectedContracts = append(selectedContracts, candidate.toItem())
+		usedTokens += candidate.tokens
+	}
+
+	selectedFiles := make([]types.ContextBundleItem, 0, len(files))
+	for _, candidate := range files {
+		if usedTokens+candidate.tokens > maxTokens {
+			exclusions = appendContextBundleExclusion(exclusions, contextBundleBudgetExclusion(candidate))
+			continue
+		}
+		selectedFiles = append(selectedFiles, candidate.toItem())
+		usedTokens += candidate.tokens
+	}
+
+	symbols := extractContextBundleSelectedSymbols(repositoryRoot, selectedFiles)
+	repositoryName := filepath.Base(repositoryRoot)
+	output := &types.ContextBundleOutput{
+		Version: contextBundleVersion,
+		Repository: types.ContextBundleRepository{
+			Root: repositoryRoot,
+			Name: repositoryName,
+		},
+		Goal: request.Goal,
+		Budget: types.ContextBundleBudget{
+			MaxTokens:  maxTokens,
+			UsedTokens: usedTokens,
+			Model:      tokenModel,
+		},
+		Terms:       terms,
+		Contracts:   selectedContracts,
+		Files:       selectedFiles,
+		Symbols:     symbols,
+		Exclusions:  exclusions,
+		GeneratedBy: contextBundleGeneratedBy,
+	}
+	return output, nil
+}
+
+func normalizeContextBundleRequest(request types.ContextBundleRequest) types.ContextBundleRequest {
+	request.RepositoryRoot = strings.TrimSpace(request.RepositoryRoot)
+	request.IssueDocumentPath = filepath.ToSlash(strings.TrimSpace(request.IssueDocumentPath))
+	request.PlanDocumentPath = filepath.ToSlash(strings.TrimSpace(request.PlanDocumentPath))
+	request.ValidationTarget = strings.TrimSpace(request.ValidationTarget)
+	request.Model = strings.TrimSpace(request.Model)
+	request.Goal.ID = strings.TrimSpace(request.Goal.ID)
+	request.Goal.Kind = strings.TrimSpace(request.Goal.Kind)
+	request.Goal.Title = strings.TrimSpace(request.Goal.Title)
+	request.Goal.Body = strings.TrimSpace(request.Goal.Body)
+	request.Goal.Category = strings.TrimSpace(request.Goal.Category)
+	request.IncludePaths = normalizeContextBundlePatterns(request.IncludePaths)
+	request.ExcludePaths = normalizeContextBundlePatterns(request.ExcludePaths)
+	return request
+}
+
+func normalizeContextBundlePatterns(patterns []string) []string {
+	var normalized []string
+	for _, pattern := range patterns {
+		trimmed := filepath.ToSlash(strings.TrimSpace(pattern))
+		if trimmed != "" {
+			normalized = append(normalized, trimmed)
+		}
+	}
+	return normalized
+}
+
+func deriveContextBundleTerms(request types.ContextBundleRequest) []string {
+	termCounts := map[string]int{}
+	source := strings.Join([]string{
+		request.Goal.ID,
+		request.Goal.Kind,
+		request.Goal.Category,
+		request.Goal.Title,
+		request.Goal.Body,
+		request.ValidationTarget,
+	}, " ")
+	for _, match := range contextBundleWordPattern.FindAllString(source, -1) {
+		term := strings.ToLower(match)
+		term = strings.TrimFunc(term, func(r rune) bool {
+			return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+		})
+		if len(term) < 3 {
+			continue
+		}
+		if _, stopped := contextBundleStopWords[term]; stopped {
+			continue
+		}
+		termCounts[term]++
+	}
+	terms := make([]string, 0, len(termCounts))
+	for term := range termCounts {
+		terms = append(terms, term)
+	}
+	sort.Slice(terms, func(leftIndex, rightIndex int) bool {
+		left := terms[leftIndex]
+		right := terms[rightIndex]
+		if termCounts[left] == termCounts[right] {
+			return left < right
+		}
+		return termCounts[left] > termCounts[right]
+	})
+	if len(terms) > 24 {
+		terms = terms[:24]
+	}
+	return terms
+}
+
+func classifyContextBundleRole(relativePath string, request types.ContextBundleRequest) string {
+	normalized := filepath.ToSlash(relativePath)
+	base := filepath.Base(normalized)
+	if normalized == request.IssueDocumentPath || normalized == ".mprlab/ISSUES.md" {
+		return contextBundleRoleIssueDoc
+	}
+	if normalized == request.PlanDocumentPath || normalized == ".mprlab/PLAN.md" || normalized == ".mprlab/PLANNING.md" {
+		return contextBundleRolePlan
+	}
+	switch {
+	case base == "AGENTS.md",
+		base == "ARCHITECTURE.md",
+		base == "README.md",
+		base == "PRD.md",
+		normalized == ".mprlab/POLICY.md",
+		strings.HasPrefix(normalized, ".mprlab/AGENTS."):
+		return contextBundleRoleContract
+	case isContextBundleTestPath(normalized):
+		return contextBundleRoleTest
+	case isContextBundleRuntimePath(normalized):
+		return contextBundleRoleRuntime
+	case strings.HasSuffix(normalized, ".md") || strings.HasPrefix(normalized, "docs/"):
+		return contextBundleRoleDocs
+	case isContextBundleConfigPath(normalized):
+		return contextBundleRoleConfig
+	case isContextBundleSourcePath(normalized):
+		return contextBundleRoleImpl
+	default:
+		return contextBundleRoleAsset
+	}
+}
+
+func isContextBundleTestPath(relativePath string) bool {
+	base := filepath.Base(relativePath)
+	return strings.Contains(relativePath, "/test/") ||
+		strings.Contains(relativePath, "/tests/") ||
+		strings.Contains(relativePath, "__tests__/") ||
+		strings.HasSuffix(base, "_test.go") ||
+		strings.HasSuffix(base, ".test.js") ||
+		strings.HasSuffix(base, ".spec.js") ||
+		strings.HasSuffix(base, "_test.py")
+}
+
+func isContextBundleRuntimePath(relativePath string) bool {
+	base := filepath.Base(relativePath)
+	switch base {
+	case "Makefile", "Dockerfile", "docker-compose.yml", "docker-compose.yaml", "go.mod", "go.sum", "package.json", "package-lock.json", "pyproject.toml", "requirements.txt":
+		return true
+	default:
+		return strings.HasPrefix(relativePath, ".github/workflows/")
+	}
+}
+
+func isContextBundleConfigPath(relativePath string) bool {
+	extension := strings.ToLower(filepath.Ext(relativePath))
+	switch extension {
+	case ".json", ".toml", ".yaml", ".yml", ".ini", ".env":
+		return true
+	default:
+		return false
+	}
+}
+
+func isContextBundleSourcePath(relativePath string) bool {
+	extension := strings.ToLower(filepath.Ext(relativePath))
+	switch extension {
+	case ".go", ".js", ".mjs", ".cjs", ".ts", ".tsx", ".jsx", ".py", ".css", ".html", ".sh":
+		return true
+	default:
+		return false
+	}
+}
+
+func scoreContextBundleFile(relativePath string, content string, role string, terms []string, includePatterns []string) (int, string) {
+	lowerPath := strings.ToLower(relativePath)
+	lowerContent := strings.ToLower(content)
+	score := 0
+	pathMatches := 0
+	contentMatches := 0
+	for _, term := range terms {
+		if strings.Contains(lowerPath, term) {
+			pathMatches++
+			score += 30
+		}
+		count := strings.Count(lowerContent, term)
+		if count > 0 {
+			contentMatches += count
+			if count > 8 {
+				count = 8
+			}
+			score += count * 4
+		}
+	}
+	switch role {
+	case contextBundleRoleImpl:
+		score += 12
+	case contextBundleRoleTest:
+		score += 10
+	case contextBundleRoleRuntime:
+		score += 6
+	case contextBundleRoleDocs:
+		score -= 8
+	case contextBundleRoleConfig:
+		score += 2
+	}
+	if matchesContextBundlePattern(relativePath, includePatterns) {
+		score += 80
+	}
+	reasonParts := []string{}
+	if pathMatches > 0 {
+		reasonParts = append(reasonParts, fmt.Sprintf("%d goal term path matches", pathMatches))
+	}
+	if contentMatches > 0 {
+		reasonParts = append(reasonParts, fmt.Sprintf("%d goal term content matches", contentMatches))
+	}
+	if len(reasonParts) == 0 {
+		reasonParts = append(reasonParts, "role relevance")
+	}
+	return score, strings.Join(reasonParts, "; ")
+}
+
+func matchesContextBundlePattern(relativePath string, patterns []string) bool {
+	if len(patterns) == 0 {
+		return false
+	}
+	for _, pattern := range patterns {
+		if pattern == relativePath {
+			return true
+		}
+		if matched, matchErr := filepath.Match(pattern, relativePath); matchErr == nil && matched {
+			return true
+		}
+		if strings.HasSuffix(pattern, "/") && strings.HasPrefix(relativePath, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func contextBundleReason(relativePath string, role string, scoredReason string) string {
+	switch role {
+	case contextBundleRoleContract:
+		return contextBundleReasonContract
+	case contextBundleRoleIssueDoc:
+		return "active issue document"
+	case contextBundleRolePlan:
+		return "current planning document"
+	default:
+		if scoredReason != "" {
+			return scoredReason
+		}
+		return "selected for context bundle"
+	}
+}
+
+func buildContextBundleCandidate(relativePath string, role string, reason string, score int, content string, maxRunes int, counter tokenizer.Counter) (contextBundleCandidate, error) {
+	excerpt, lineStart, lineEnd := contextBundleExcerpt(content, maxRunes)
+	tokens, countErr := counter.CountString(excerpt)
+	if countErr != nil {
+		return contextBundleCandidate{}, fmt.Errorf("count tokens for %s: %w", relativePath, countErr)
+	}
+	hash := sha256.Sum256([]byte(content))
+	return contextBundleCandidate{
+		path:      relativePath,
+		role:      role,
+		reason:    reason,
+		score:     score,
+		content:   excerpt,
+		lineStart: lineStart,
+		lineEnd:   lineEnd,
+		tokens:    tokens,
+		hash:      hex.EncodeToString(hash[:]),
+	}, nil
+}
+
+func contextBundleExcerpt(content string, maxRunes int) (string, int, int) {
+	lineStart := 1
+	runes := []rune(content)
+	if maxRunes <= 0 || len(runes) <= maxRunes {
+		return content, lineStart, countContextBundleLines(content)
+	}
+	excerpt := string(runes[:maxRunes])
+	return excerpt, lineStart, countContextBundleLines(excerpt)
+}
+
+func countContextBundleLines(content string) int {
+	if content == "" {
+		return 1
+	}
+	lines := strings.Count(content, "\n") + 1
+	if strings.HasSuffix(content, "\n") && lines > 1 {
+		lines--
+	}
+	return lines
+}
+
+func sortContextBundleCandidates(candidates []contextBundleCandidate) {
+	sort.SliceStable(candidates, func(leftIndex, rightIndex int) bool {
+		left := candidates[leftIndex]
+		right := candidates[rightIndex]
+		if left.score == right.score {
+			return left.path < right.path
+		}
+		return left.score > right.score
+	})
+}
+
+func (candidate contextBundleCandidate) toItem() types.ContextBundleItem {
+	return types.ContextBundleItem{
+		Path:      candidate.path,
+		Role:      candidate.role,
+		Reason:    candidate.reason,
+		Score:     candidate.score,
+		Tokens:    candidate.tokens,
+		SHA256:    candidate.hash,
+		LineStart: candidate.lineStart,
+		LineEnd:   candidate.lineEnd,
+		Content:   candidate.content,
+	}
+}
+
+func contextBundleBudgetExclusion(candidate contextBundleCandidate) types.ContextBundleExclusion {
+	return types.ContextBundleExclusion{
+		Path:   candidate.path,
+		Role:   candidate.role,
+		Reason: "token budget exceeded",
+		Score:  candidate.score,
+	}
+}
+
+func appendContextBundleExclusion(exclusions []types.ContextBundleExclusion, exclusion types.ContextBundleExclusion) []types.ContextBundleExclusion {
+	const limit = 64
+	if len(exclusions) >= limit {
+		return exclusions
+	}
+	return append(exclusions, exclusion)
+}
+
+func extractContextBundleSelectedSymbols(root string, files []types.ContextBundleItem) []types.ContextBundleSymbol {
+	var symbols []types.ContextBundleSymbol
+	for _, file := range files {
+		if file.Role != contextBundleRoleImpl && file.Role != contextBundleRoleTest {
+			continue
+		}
+		contentBytes, readErr := os.ReadFile(filepath.Join(root, file.Path))
+		if readErr != nil {
+			continue
+		}
+		symbols = append(symbols, extractContextSymbols(root, file.Path, contentBytes)...)
+	}
+	sort.SliceStable(symbols, func(leftIndex, rightIndex int) bool {
+		left := symbols[leftIndex]
+		right := symbols[rightIndex]
+		if left.Path == right.Path {
+			if left.LineStart == right.LineStart {
+				return left.QualifiedName < right.QualifiedName
+			}
+			return left.LineStart < right.LineStart
+		}
+		return left.Path < right.Path
+	})
+	return symbols
+}

--- a/internal/commands/context_bundle.go
+++ b/internal/commands/context_bundle.go
@@ -58,6 +58,19 @@ var contextBundleDefaultExclusions = []string{
 	"build/",
 	"coverage/",
 	"tmp/",
+	"secret/",
+	"secrets/",
+	".env",
+	".env.*",
+	"*.env",
+	"*.env.local",
+	"*.env.development",
+	"*.env.production",
+	"*.env.test",
+	"*.key",
+	"*.pem",
+	"*.p8",
+	"*.p12",
 	"*.png",
 	"*.jpg",
 	"*.jpeg",
@@ -222,7 +235,7 @@ func BuildContextBundle(ctx context.Context, options ContextBundleOptions) (*typ
 	var usedTokens int
 	selectedContracts := make([]types.ContextBundleItem, 0, len(contracts))
 	for _, candidate := range contracts {
-		if candidate.tokens > maxTokens && len(selectedContracts) > 0 {
+		if usedTokens+candidate.tokens > maxTokens {
 			exclusions = appendContextBundleExclusion(exclusions, contextBundleBudgetExclusion(candidate))
 			continue
 		}

--- a/internal/commands/context_bundle_test.go
+++ b/internal/commands/context_bundle_test.go
@@ -1,0 +1,167 @@
+package commands_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tyemirov/ctx/internal/commands"
+	"github.com/tyemirov/ctx/internal/types"
+)
+
+const contextBundleTestModel = "stub-model"
+
+func TestBuildContextBundleEnforcesCumulativeContractBudget(testingHandle *testing.T) {
+	testCases := []struct {
+		testName                  string
+		maxTokens                 int
+		expectedSelectedContracts int
+	}{
+		{
+			testName:                  "selects only contracts within cumulative budget",
+			maxTokens:                 70,
+			expectedSelectedContracts: 1,
+		},
+		{
+			testName:                  "admits additional contracts while budget remains",
+			maxTokens:                 90,
+			expectedSelectedContracts: 2,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		testingHandle.Run(testCase.testName, func(subtestHandle *testing.T) {
+			repositoryRoot := subtestHandle.TempDir()
+			contractContent := strings.Repeat("x", 40)
+			writeContextBundleTestFile(subtestHandle, repositoryRoot, "AGENTS.md", contractContent)
+			writeContextBundleTestFile(subtestHandle, repositoryRoot, ".mprlab/POLICY.md", contractContent)
+			writeContextBundleTestFile(subtestHandle, repositoryRoot, ".mprlab/ISSUES.md", contractContent)
+
+			bundle := buildContextBundleForTest(subtestHandle, types.ContextBundleRequest{
+				RepositoryRoot: repositoryRoot,
+				MaxTokens:      testCase.maxTokens,
+				Goal: types.ContextBundleGoal{
+					ID:    "B001",
+					Title: "Keep contract budget bounded",
+				},
+			})
+
+			if bundle.Budget.UsedTokens > bundle.Budget.MaxTokens {
+				subtestHandle.Fatalf("used tokens exceeded max tokens: got %d, max %d", bundle.Budget.UsedTokens, bundle.Budget.MaxTokens)
+			}
+			if len(bundle.Contracts) != testCase.expectedSelectedContracts {
+				subtestHandle.Fatalf("expected %d selected contracts, got %d", testCase.expectedSelectedContracts, len(bundle.Contracts))
+			}
+			if !contextBundleHasExclusion(bundle.Exclusions, "token budget exceeded") {
+				subtestHandle.Fatalf("expected token budget exclusion, got %+v", bundle.Exclusions)
+			}
+		})
+	}
+}
+
+func TestBuildContextBundleOmitsSecretEnvironmentFiles(testingHandle *testing.T) {
+	testCases := []struct {
+		testName   string
+		secretPath string
+	}{
+		{
+			testName:   "dot env local",
+			secretPath: ".env.local",
+		},
+		{
+			testName:   "env production suffix",
+			secretPath: "server.env.production",
+		},
+		{
+			testName:   "secret key directory",
+			secretPath: "secrets/provider.key",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		testingHandle.Run(testCase.testName, func(subtestHandle *testing.T) {
+			repositoryRoot := subtestHandle.TempDir()
+			secretMarker := "super-secret-api-key-context"
+			writeContextBundleTestFile(subtestHandle, repositoryRoot, "AGENTS.md", "contract\n")
+			writeContextBundleTestFile(subtestHandle, repositoryRoot, testCase.secretPath, secretMarker)
+			writeContextBundleTestFile(subtestHandle, repositoryRoot, "src/config.js", "export const apiKeyConfig = 'api key config context';\n")
+
+			bundle := buildContextBundleForTest(subtestHandle, types.ContextBundleRequest{
+				RepositoryRoot: repositoryRoot,
+				MaxTokens:      1000,
+				IncludePaths:   []string{testCase.secretPath},
+				Goal: types.ContextBundleGoal{
+					ID:    "B002",
+					Title: "Add api key config context",
+				},
+			})
+
+			if contextBundleHasItem(bundle.Files, testCase.secretPath) || contextBundleHasItem(bundle.Contracts, testCase.secretPath) {
+				subtestHandle.Fatalf("secret path %s was included in bundle", testCase.secretPath)
+			}
+			if contextBundleContainsContent(bundle.Files, secretMarker) || contextBundleContainsContent(bundle.Contracts, secretMarker) {
+				subtestHandle.Fatalf("secret content marker leaked into bundle")
+			}
+			if !contextBundleHasItem(bundle.Files, "src/config.js") {
+				subtestHandle.Fatalf("expected non-secret config file to remain eligible, got %+v", bundle.Files)
+			}
+		})
+	}
+}
+
+func buildContextBundleForTest(testingHandle *testing.T, request types.ContextBundleRequest) types.ContextBundleOutput {
+	testingHandle.Helper()
+
+	bundle, buildError := commands.BuildContextBundle(context.Background(), commands.ContextBundleOptions{
+		Request:      request,
+		TokenCounter: stubCounter{},
+		TokenModel:   contextBundleTestModel,
+	})
+	if buildError != nil {
+		testingHandle.Fatalf("build context bundle: %v", buildError)
+	}
+	return *bundle
+}
+
+func writeContextBundleTestFile(testingHandle *testing.T, repositoryRoot string, relativePath string, content string) {
+	testingHandle.Helper()
+
+	filePath := filepath.Join(repositoryRoot, relativePath)
+	if mkdirError := os.MkdirAll(filepath.Dir(filePath), 0o755); mkdirError != nil {
+		testingHandle.Fatalf("create parent directory for %s: %v", relativePath, mkdirError)
+	}
+	if writeError := os.WriteFile(filePath, []byte(content), 0o600); writeError != nil {
+		testingHandle.Fatalf("write %s: %v", relativePath, writeError)
+	}
+}
+
+func contextBundleHasItem(items []types.ContextBundleItem, path string) bool {
+	for _, item := range items {
+		if item.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
+func contextBundleContainsContent(items []types.ContextBundleItem, content string) bool {
+	for _, item := range items {
+		if strings.Contains(item.Content, content) {
+			return true
+		}
+	}
+	return false
+}
+
+func contextBundleHasExclusion(exclusions []types.ContextBundleExclusion, reason string) bool {
+	for _, exclusion := range exclusions {
+		if exclusion.Reason == reason {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/commands/context_symbols.go
+++ b/internal/commands/context_symbols.go
@@ -1,0 +1,250 @@
+package commands
+
+import (
+	"bytes"
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"path/filepath"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	javascript "github.com/smacker/go-tree-sitter/javascript"
+	python "github.com/smacker/go-tree-sitter/python"
+	"github.com/tyemirov/ctx/internal/types"
+)
+
+const (
+	symbolLanguageGo         = "go"
+	symbolLanguageJavaScript = "javascript"
+	symbolLanguagePython     = "python"
+	symbolKindClass          = "class"
+	symbolKindFunction       = "function"
+	symbolKindMethod         = "method"
+	symbolKindType           = "type"
+)
+
+func extractContextSymbols(root string, relativePath string, content []byte) []types.ContextBundleSymbol {
+	switch strings.ToLower(filepath.Ext(relativePath)) {
+	case ".go":
+		return extractGoContextSymbols(root, relativePath, content)
+	case ".js", ".mjs", ".cjs":
+		return extractJavaScriptContextSymbols(relativePath, content)
+	case ".py":
+		return extractPythonContextSymbols(relativePath, content)
+	default:
+		return nil
+	}
+}
+
+func extractGoContextSymbols(root string, relativePath string, content []byte) []types.ContextBundleSymbol {
+	fileSet := token.NewFileSet()
+	parsedFile, parseErr := parser.ParseFile(fileSet, filepath.Join(root, relativePath), content, parser.SkipObjectResolution)
+	if parseErr != nil {
+		return nil
+	}
+	moduleName := contextSymbolModuleName(relativePath)
+	var symbols []types.ContextBundleSymbol
+	ast.Inspect(parsedFile, func(node ast.Node) bool {
+		switch typed := node.(type) {
+		case *ast.FuncDecl:
+			if typed.Name == nil {
+				return true
+			}
+			name := typed.Name.Name
+			kind := symbolKindFunction
+			if typed.Recv != nil && len(typed.Recv.List) > 0 {
+				kind = symbolKindMethod
+				name = goReceiverName(fileSet, typed.Recv.List[0].Type) + "." + name
+			}
+			symbols = append(symbols, types.ContextBundleSymbol{
+				Path:          relativePath,
+				Language:      symbolLanguageGo,
+				Kind:          kind,
+				Name:          typed.Name.Name,
+				QualifiedName: moduleName + "." + name,
+				LineStart:     fileSet.Position(typed.Pos()).Line,
+				LineEnd:       fileSet.Position(typed.End()).Line,
+			})
+			return true
+		case *ast.TypeSpec:
+			if typed.Name == nil {
+				return true
+			}
+			symbols = append(symbols, types.ContextBundleSymbol{
+				Path:          relativePath,
+				Language:      symbolLanguageGo,
+				Kind:          symbolKindType,
+				Name:          typed.Name.Name,
+				QualifiedName: moduleName + "." + typed.Name.Name,
+				LineStart:     fileSet.Position(typed.Pos()).Line,
+				LineEnd:       fileSet.Position(typed.End()).Line,
+			})
+			return true
+		default:
+			return true
+		}
+	})
+	return symbols
+}
+
+func goReceiverName(fileSet *token.FileSet, expression ast.Expr) string {
+	var buffer bytes.Buffer
+	if printErr := printer.Fprint(&buffer, fileSet, expression); printErr != nil {
+		return "receiver"
+	}
+	name := strings.TrimSpace(buffer.String())
+	name = strings.TrimPrefix(name, "*")
+	return name
+}
+
+func extractJavaScriptContextSymbols(relativePath string, content []byte) []types.ContextBundleSymbol {
+	parserHandle := sitter.NewParser()
+	parserHandle.SetLanguage(javascript.GetLanguage())
+	tree := parserHandle.Parse(nil, content)
+	if tree == nil {
+		return nil
+	}
+	var symbols []types.ContextBundleSymbol
+	walkJavaScriptContextSymbols(tree.RootNode(), relativePath, content, nil, &symbols)
+	return symbols
+}
+
+func walkJavaScriptContextSymbols(node *sitter.Node, relativePath string, content []byte, classStack []string, symbols *[]types.ContextBundleSymbol) {
+	if node == nil {
+		return
+	}
+	switch node.Type() {
+	case "class_declaration":
+		name := contextNodeName(node, content)
+		if name != "" {
+			qualifiedName := contextQualifiedName(relativePath, classStack, name)
+			*symbols = append(*symbols, contextSitterSymbol(relativePath, symbolLanguageJavaScript, symbolKindClass, name, qualifiedName, node))
+			nextStack := append(append([]string{}, classStack...), name)
+			for index := 0; index < int(node.ChildCount()); index++ {
+				walkJavaScriptContextSymbols(node.Child(index), relativePath, content, nextStack, symbols)
+			}
+			return
+		}
+	case "function_declaration":
+		name := contextNodeName(node, content)
+		if name != "" {
+			qualifiedName := contextQualifiedName(relativePath, classStack, name)
+			*symbols = append(*symbols, contextSitterSymbol(relativePath, symbolLanguageJavaScript, symbolKindFunction, name, qualifiedName, node))
+		}
+	case "method_definition":
+		name := contextNodeName(node, content)
+		if name != "" {
+			qualifiedName := contextQualifiedName(relativePath, classStack, name)
+			*symbols = append(*symbols, contextSitterSymbol(relativePath, symbolLanguageJavaScript, symbolKindMethod, name, qualifiedName, node))
+		}
+	case "variable_declarator":
+		nameNode := node.ChildByFieldName("name")
+		valueNode := node.ChildByFieldName("value")
+		if nameNode != nil && valueNode != nil && isJavaScriptCallableValue(valueNode.Type()) {
+			name := strings.TrimSpace(string(content[nameNode.StartByte():nameNode.EndByte()]))
+			qualifiedName := contextQualifiedName(relativePath, classStack, name)
+			*symbols = append(*symbols, contextSitterSymbol(relativePath, symbolLanguageJavaScript, symbolKindFunction, name, qualifiedName, node))
+		}
+	}
+	for index := 0; index < int(node.ChildCount()); index++ {
+		walkJavaScriptContextSymbols(node.Child(index), relativePath, content, classStack, symbols)
+	}
+}
+
+func isJavaScriptCallableValue(nodeType string) bool {
+	switch nodeType {
+	case "arrow_function", "function", "function_expression", "generator_function":
+		return true
+	default:
+		return false
+	}
+}
+
+func extractPythonContextSymbols(relativePath string, content []byte) []types.ContextBundleSymbol {
+	parserHandle := sitter.NewParser()
+	parserHandle.SetLanguage(python.GetLanguage())
+	tree := parserHandle.Parse(nil, content)
+	if tree == nil {
+		return nil
+	}
+	var symbols []types.ContextBundleSymbol
+	walkPythonContextSymbols(tree.RootNode(), relativePath, content, nil, &symbols)
+	return symbols
+}
+
+func walkPythonContextSymbols(node *sitter.Node, relativePath string, content []byte, classStack []string, symbols *[]types.ContextBundleSymbol) {
+	if node == nil {
+		return
+	}
+	switch node.Type() {
+	case "class_definition":
+		name := contextNodeName(node, content)
+		if name != "" {
+			qualifiedName := contextQualifiedName(relativePath, classStack, name)
+			*symbols = append(*symbols, contextSitterSymbol(relativePath, symbolLanguagePython, symbolKindClass, name, qualifiedName, node))
+			nextStack := append(append([]string{}, classStack...), name)
+			for index := 0; index < int(node.ChildCount()); index++ {
+				walkPythonContextSymbols(node.Child(index), relativePath, content, nextStack, symbols)
+			}
+			return
+		}
+	case "function_definition":
+		name := contextNodeName(node, content)
+		if name != "" {
+			kind := symbolKindFunction
+			if len(classStack) > 0 {
+				kind = symbolKindMethod
+			}
+			qualifiedName := contextQualifiedName(relativePath, classStack, name)
+			*symbols = append(*symbols, contextSitterSymbol(relativePath, symbolLanguagePython, kind, name, qualifiedName, node))
+		}
+	}
+	for index := 0; index < int(node.ChildCount()); index++ {
+		walkPythonContextSymbols(node.Child(index), relativePath, content, classStack, symbols)
+	}
+}
+
+func contextNodeName(node *sitter.Node, content []byte) string {
+	nameNode := node.ChildByFieldName("name")
+	if nameNode == nil {
+		return ""
+	}
+	return strings.TrimSpace(string(content[nameNode.StartByte():nameNode.EndByte()]))
+}
+
+func contextSitterSymbol(relativePath string, language string, kind string, name string, qualifiedName string, node *sitter.Node) types.ContextBundleSymbol {
+	return types.ContextBundleSymbol{
+		Path:          relativePath,
+		Language:      language,
+		Kind:          kind,
+		Name:          name,
+		QualifiedName: qualifiedName,
+		LineStart:     int(node.StartPoint().Row) + 1,
+		LineEnd:       int(node.EndPoint().Row) + 1,
+	}
+}
+
+func contextQualifiedName(relativePath string, stack []string, name string) string {
+	parts := []string{contextSymbolModuleName(relativePath)}
+	parts = append(parts, stack...)
+	parts = append(parts, name)
+	return strings.Join(parts, ".")
+}
+
+func contextSymbolModuleName(relativePath string) string {
+	withoutExtension := strings.TrimSuffix(filepath.ToSlash(relativePath), filepath.Ext(relativePath))
+	segments := strings.Split(withoutExtension, "/")
+	cleaned := make([]string, 0, len(segments))
+	for _, segment := range segments {
+		segment = strings.TrimSpace(segment)
+		if segment != "" {
+			cleaned = append(cleaned, segment)
+		}
+	}
+	if len(cleaned) == 0 {
+		return "root"
+	}
+	return strings.Join(cleaned, ".")
+}

--- a/internal/output/context_bundle.go
+++ b/internal/output/context_bundle.go
@@ -1,0 +1,110 @@
+package output
+
+import (
+	"encoding/json"
+
+	"github.com/tyemirov/ctx/internal/types"
+)
+
+// RenderContextBundleJSON marshals a context bundle as deterministic JSON.
+func RenderContextBundleJSON(bundle *types.ContextBundleOutput) (string, error) {
+	encoded, encodeErr := json.MarshalIndent(bundle, indentPrefix, indentSpacer)
+	return string(encoded), encodeErr
+}
+
+// RenderContextBundleToon renders the context bundle in TOON format for prompt inclusion.
+func RenderContextBundleToon(bundle *types.ContextBundleOutput) string {
+	if bundle == nil {
+		return ""
+	}
+	builder := toonBuilder{}
+	builder.writeIndent(0)
+	builder.buffer.WriteString("contextBundle:\n")
+	builder.writeField(1, toonField{key: "version", value: bundle.Version})
+	builder.writeField(1, toonField{key: "generatedBy", value: bundle.GeneratedBy})
+	builder.writeIndent(1)
+	builder.buffer.WriteString("repository:\n")
+	builder.writeField(2, toonField{key: "root", value: bundle.Repository.Root})
+	builder.writeField(2, toonField{key: "name", value: bundle.Repository.Name})
+	builder.writeIndent(1)
+	builder.buffer.WriteString("goal:\n")
+	if bundle.Goal.ID != "" {
+		builder.writeField(2, toonField{key: "id", value: bundle.Goal.ID})
+	}
+	if bundle.Goal.Kind != "" {
+		builder.writeField(2, toonField{key: "kind", value: bundle.Goal.Kind})
+	}
+	if bundle.Goal.Category != "" {
+		builder.writeField(2, toonField{key: "category", value: bundle.Goal.Category})
+	}
+	builder.writeField(2, toonField{key: "title", value: bundle.Goal.Title})
+	if bundle.Goal.Body != "" {
+		builder.writeField(2, toonField{key: "body", value: bundle.Goal.Body})
+	}
+	builder.writeIndent(1)
+	builder.buffer.WriteString("budget:\n")
+	builder.writeField(2, toonField{key: "maxTokens", value: bundle.Budget.MaxTokens})
+	builder.writeField(2, toonField{key: "usedTokens", value: bundle.Budget.UsedTokens})
+	builder.writeField(2, toonField{key: "model", value: bundle.Budget.Model})
+	builder.writeScalarArray(1, "terms", bundle.Terms)
+	writeContextBundleItems(&builder, 1, "contracts", bundle.Contracts)
+	writeContextBundleItems(&builder, 1, "files", bundle.Files)
+	writeContextBundleSymbols(&builder, 1, bundle.Symbols)
+	writeContextBundleExclusions(&builder, 1, bundle.Exclusions)
+	return builder.String()
+}
+
+func writeContextBundleItems(builder *toonBuilder, indent int, name string, items []types.ContextBundleItem) {
+	builder.writeArrayHeader(indent, name, len(items))
+	for _, item := range items {
+		fields := []toonField{
+			{key: "path", value: item.Path},
+			{key: "role", value: item.Role},
+			{key: "reason", value: item.Reason},
+		}
+		if item.Score != 0 {
+			fields = append(fields, toonField{key: "score", value: item.Score})
+		}
+		fields = append(fields,
+			toonField{key: "tokens", value: item.Tokens},
+			toonField{key: "sha256", value: item.SHA256},
+			toonField{key: "lineStart", value: item.LineStart},
+			toonField{key: "lineEnd", value: item.LineEnd},
+			toonField{key: "content", value: item.Content},
+		)
+		builder.writeObjectInArray(indent+1, fields)
+	}
+}
+
+func writeContextBundleSymbols(builder *toonBuilder, indent int, symbols []types.ContextBundleSymbol) {
+	builder.writeArrayHeader(indent, "symbols", len(symbols))
+	for _, symbol := range symbols {
+		fields := []toonField{
+			{key: "path", value: symbol.Path},
+			{key: "language", value: symbol.Language},
+			{key: "kind", value: symbol.Kind},
+			{key: "name", value: symbol.Name},
+			{key: "qualifiedName", value: symbol.QualifiedName},
+			{key: "lineStart", value: symbol.LineStart},
+			{key: "lineEnd", value: symbol.LineEnd},
+		}
+		builder.writeObjectInArray(indent+1, fields)
+	}
+}
+
+func writeContextBundleExclusions(builder *toonBuilder, indent int, exclusions []types.ContextBundleExclusion) {
+	builder.writeArrayHeader(indent, "exclusions", len(exclusions))
+	for _, exclusion := range exclusions {
+		fields := []toonField{
+			{key: "path", value: exclusion.Path},
+		}
+		if exclusion.Role != "" {
+			fields = append(fields, toonField{key: "role", value: exclusion.Role})
+		}
+		fields = append(fields, toonField{key: "reason", value: exclusion.Reason})
+		if exclusion.Score != 0 {
+			fields = append(fields, toonField{key: "score", value: exclusion.Score})
+		}
+		builder.writeObjectInArray(indent+1, fields)
+	}
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -12,6 +12,7 @@ const (
 	CommandContent   = "content"
 	CommandCallChain = "callchain"
 	CommandDoc       = "doc"
+	CommandBundle    = "bundle"
 
 	FormatRaw  = "raw"
 	FormatToon = "toon"
@@ -85,4 +86,85 @@ type OutputSummary struct {
 	TotalSize   string `json:"totalSize" xml:"totalSize"`
 	TotalTokens int    `json:"totalTokens,omitempty" xml:"totalTokens,omitempty"`
 	Model       string `json:"model,omitempty" xml:"model,omitempty"`
+}
+
+// ContextBundleRequest describes the goal-oriented repository context to assemble.
+type ContextBundleRequest struct {
+	RepositoryRoot    string            `json:"repositoryRoot"`
+	Goal              ContextBundleGoal `json:"goal"`
+	IssueDocumentPath string            `json:"issueDocumentPath,omitempty"`
+	PlanDocumentPath  string            `json:"planDocumentPath,omitempty"`
+	ValidationTarget  string            `json:"validationTarget,omitempty"`
+	MaxTokens         int               `json:"maxTokens,omitempty"`
+	Model             string            `json:"model,omitempty"`
+	IncludePaths      []string          `json:"includePaths,omitempty"`
+	ExcludePaths      []string          `json:"excludePaths,omitempty"`
+}
+
+// ContextBundleGoal is the concrete work item the context bundle should support.
+type ContextBundleGoal struct {
+	ID       string `json:"id,omitempty"`
+	Kind     string `json:"kind,omitempty"`
+	Title    string `json:"title"`
+	Body     string `json:"body,omitempty"`
+	Category string `json:"category,omitempty"`
+}
+
+// ContextBundleOutput is the canonical JSON contract emitted by ctx bundle.
+type ContextBundleOutput struct {
+	Version     int                      `json:"version"`
+	Repository  ContextBundleRepository  `json:"repository"`
+	Goal        ContextBundleGoal        `json:"goal"`
+	Budget      ContextBundleBudget      `json:"budget"`
+	Terms       []string                 `json:"terms"`
+	Contracts   []ContextBundleItem      `json:"contracts"`
+	Files       []ContextBundleItem      `json:"files"`
+	Symbols     []ContextBundleSymbol    `json:"symbols,omitempty"`
+	Exclusions  []ContextBundleExclusion `json:"exclusions,omitempty"`
+	GeneratedBy string                   `json:"generatedBy"`
+}
+
+// ContextBundleRepository identifies the repository scanned for the bundle.
+type ContextBundleRepository struct {
+	Root string `json:"root"`
+	Name string `json:"name"`
+}
+
+// ContextBundleBudget records the token accounting used for selection.
+type ContextBundleBudget struct {
+	MaxTokens  int    `json:"maxTokens"`
+	UsedTokens int    `json:"usedTokens"`
+	Model      string `json:"model"`
+}
+
+// ContextBundleItem is a selected contract or implementation file excerpt.
+type ContextBundleItem struct {
+	Path      string `json:"path"`
+	Role      string `json:"role"`
+	Reason    string `json:"reason"`
+	Score     int    `json:"score,omitempty"`
+	Tokens    int    `json:"tokens"`
+	SHA256    string `json:"sha256"`
+	LineStart int    `json:"lineStart"`
+	LineEnd   int    `json:"lineEnd"`
+	Content   string `json:"content"`
+}
+
+// ContextBundleSymbol describes a structural source symbol found in a selected file.
+type ContextBundleSymbol struct {
+	Path          string `json:"path"`
+	Language      string `json:"language"`
+	Kind          string `json:"kind"`
+	Name          string `json:"name"`
+	QualifiedName string `json:"qualifiedName"`
+	LineStart     int    `json:"lineStart"`
+	LineEnd       int    `json:"lineEnd"`
+}
+
+// ContextBundleExclusion records a file that was considered but left out of the bundle.
+type ContextBundleExclusion struct {
+	Path   string `json:"path"`
+	Role   string `json:"role,omitempty"`
+	Reason string `json:"reason"`
+	Score  int    `json:"score,omitempty"`
 }

--- a/tests/ctx_test.go
+++ b/tests/ctx_test.go
@@ -287,8 +287,107 @@ func TestTreeMatchesContentWithoutContentAcrossFormats(t *testing.T) {
 	}
 }
 
+func TestBundleBuildsGoalOrientedContext(t *testing.T) {
+	binary := buildBinary(t)
+	workingDir := setupTestDirectory(t, map[string]string{
+		"AGENTS.md":         "Read .mprlab/POLICY.md before changing code.\n",
+		".mprlab/POLICY.md": "Forward-only validation through integration tests.\n",
+		".mprlab/ISSUES.md": "- [ ] Add paste dropdown context for the new button.\n",
+		".mprlab/PLAN.md":   "- [ ] Build a context bundle before execution.\n",
+		"static/app/index.html": `<button id="new-issue">New</button>
+<button id="paste-issue">Paste from clipboard</button>
+`,
+		"static/js/app.js": `export function renderPasteDropdown() {
+  return "paste dropdown context builder for new issue";
+}
+
+export function preserveNewIssueAction() {
+  return renderPasteDropdown();
+}
+`,
+		"static/js/__tests__/app.test.js": `import { renderPasteDropdown } from "../app.js";
+
+test("paste dropdown remains attached to the new issue button", () => {
+  expect(renderPasteDropdown()).toContain("paste dropdown");
+});
+`,
+		"docs/paste-dropdown-notes.md": "Paste dropdown notes are supporting documentation, not the primary implementation surface.\n",
+		"CHANGELOG.md":                 "Historical paste dropdown release note.\n",
+	})
+	request := appTypes.ContextBundleRequest{
+		RepositoryRoot:    workingDir,
+		IssueDocumentPath: ".mprlab/ISSUES.md",
+		PlanDocumentPath:  ".mprlab/PLAN.md",
+		MaxTokens:         12000,
+		Model:             "gpt-4o",
+		Goal: appTypes.ContextBundleGoal{
+			ID:       "B019",
+			Kind:     "BugFix",
+			Title:    "Add Paste as a dropdown option on the New button",
+			Body:     "The execution agent needs focused frontend context for the paste dropdown and its rendered integration tests.",
+			Category: "BugFixes",
+		},
+	}
+	requestBytes, marshalErr := json.Marshal(request)
+	if marshalErr != nil {
+		t.Fatalf("marshal request: %v", marshalErr)
+	}
+	requestPath := filepath.Join(workingDir, "context-request.json")
+	if writeErr := os.WriteFile(requestPath, requestBytes, 0o644); writeErr != nil {
+		t.Fatalf("write request: %v", writeErr)
+	}
+
+	jsonOutput := runCommand(t, binary, []string{appTypes.CommandBundle, "--request", requestPath, "--format", appTypes.FormatJSON}, workingDir)
+	var bundle appTypes.ContextBundleOutput
+	if decodeErr := json.Unmarshal([]byte(jsonOutput), &bundle); decodeErr != nil {
+		t.Fatalf("decode bundle json: %v\n%s", decodeErr, jsonOutput)
+	}
+	if bundle.Version != 1 {
+		t.Fatalf("expected bundle version 1, got %d", bundle.Version)
+	}
+	for _, expectedContract := range []string{"AGENTS.md", ".mprlab/POLICY.md", ".mprlab/ISSUES.md", ".mprlab/PLAN.md"} {
+		if !bundleHasItem(bundle.Contracts, expectedContract) {
+			t.Fatalf("expected contract %s in bundle contracts: %+v", expectedContract, bundle.Contracts)
+		}
+	}
+	if !bundleHasItem(bundle.Files, "static/js/app.js") {
+		t.Fatalf("expected implementation file in bundle files: %+v", bundle.Files)
+	}
+	if !bundleHasItem(bundle.Files, "static/js/__tests__/app.test.js") {
+		t.Fatalf("expected integration test file in bundle files: %+v", bundle.Files)
+	}
+	if !bundleHasSymbol(bundle.Symbols, "static/js/app.js", "renderPasteDropdown") {
+		t.Fatalf("expected renderPasteDropdown symbol in bundle symbols: %+v", bundle.Symbols)
+	}
+
+	toonOutput := runCommand(t, binary, []string{appTypes.CommandBundle, "--request", requestPath, "--format", appTypes.FormatToon}, workingDir)
+	for _, snippet := range []string{"contextBundle:", "contracts[", "files[", "symbols["} {
+		if !strings.Contains(toonOutput, snippet) {
+			t.Fatalf("expected TOON output to contain %q\n%s", snippet, toonOutput)
+		}
+	}
+}
+
 func decodeJSONFiles(t *testing.T, data string) []appTypes.TreeOutputNode {
 	return flattenFileNodes(decodeJSONRoots(t, data))
+}
+
+func bundleHasItem(items []appTypes.ContextBundleItem, path string) bool {
+	for _, item := range items {
+		if item.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
+func bundleHasSymbol(symbols []appTypes.ContextBundleSymbol, path string, name string) bool {
+	for _, symbol := range symbols {
+		if symbol.Path == path && symbol.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 func decodeXMLFiles(t *testing.T, data string) []appTypes.TreeOutputNode {


### PR DESCRIPTION
## Summary

This update introduces a new `bundle` command that generates a goal-oriented repository context bundle in either JSON or TOON format, suitable for agentic execution workflows. It provides deterministic, contract-based extraction of relevant repository files based on a user-specified goal and context.

## Key Changes

- **New Command**: Adds a `bundle` command to the CLI to build execution contexts targeted at a specific goal, using a user-supplied JSON request.
- **Context Bundling Logic**: Implements extraction and scoring routines that select and prioritize files and documentation relevant to the provided goal, classifying repository resources into roles like contract, implementation, docs, etc., and enforcing token and size budgets.
- **Symbol Extraction**: Bundled contexts include extracted symbols for relevant code/resources to support downstream agent usage.
- **Output and Flags**: Supports output formats (`toon`, `json`), clipboard copying, and configurable request input.
- **Forward-Only Policy**: Adds documentation clearly specifying a forward-only contract discipline; backwards compatibility and shims are explicitly disallowed, enforcing contract strictness for context extraction/consumption.
- **Test Coverage**: Adds tests to verify that the bundle command produces execution-oriented context as intended.

## Rationale

This change provides